### PR TITLE
new subsections for Treptow-Köpenick and Grünheide in Brandenburg

### DIFF
--- a/files/config.local.php
+++ b/files/config.local.php
@@ -326,4 +326,10 @@
     'cottbus-zimmerstr-9',
     'cottbus-zuschka21'
   );
+
+  $CONFIG['cat']['Grünheide'] = array(
+    'freifunkgruenheide02',
+    'freifunkgruenheide07',
+    'freifunkgruenheide08'
+  );
 ?>

--- a/files/config.local.php
+++ b/files/config.local.php
@@ -296,6 +296,21 @@
     'wg1337-west'
   );
   
+  $CONFIG['cat']['Treptow / Köpenick'] = array(
+    'Adlershof-Eigeninitiative',
+    'Ahof-frieden-bbbgw', 'Ahof-frieden01', 'Ahof-frieden02', 'Ahof-frieden03',
+    'ekke-aussen', 'ekke-innen',
+    'eschenbach5',
+    'ff_Ahoernchen2',
+    'Geographie',
+    'Mitmach-Republik',
+    'PFTK',
+    'Rabenhaus',
+    'Unter_den_Linden',
+    'Wilhelminenhofstrasse',
+    'wop-sued'
+  );
+
   $CONFIG['cat']['Cottbuss'] = array(
     'cottbus-karlstr24',
     'cottbus-kreuzkirche',


### PR DESCRIPTION
add subsection for Treptow-Köpenick and area of Grünheide in Brandenburg
