### PR TITLE
monitor.berlin: Set $CONFIG['showload'] to false to make splashscree faster

### DIFF
--- a/files/config.local.php
+++ b/files/config.local.php
@@ -6,6 +6,7 @@
   $CONFIG['overview'] = array('load', 'cpu', 'memory', 'interface');
   $CONFIG['network_datasize'] = 'bits';
   $CONFIG['percentile'] = 95;
+  $CONFIG['showload'] = false;
 
   $CONFIG['cat']['freifunk.net'] = array(
     'www.freifunk.net'


### PR DESCRIPTION
The configuration file config.local.php is now set so that showload is false.
This resulted in a great improvement on the load time for the splash page,
saving time going through all the rrd files to get the current load.